### PR TITLE
Unify fields with autowire

### DIFF
--- a/catwatch-backend/src/main/java/org/zalando/catwatch/backend/DebugBean.java
+++ b/catwatch-backend/src/main/java/org/zalando/catwatch/backend/DebugBean.java
@@ -1,25 +1,28 @@
 package org.zalando.catwatch.backend;
 
-import static com.google.common.base.Joiner.on;
-import static java.util.Arrays.stream;
-
-import javax.annotation.PostConstruct;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.PostConstruct;
+
+import static com.google.common.base.Joiner.on;
+import static java.util.Arrays.stream;
+
 @Component
 @ConditionalOnProperty("debug")
 public class DebugBean {
 
-	@Autowired
-	private Environment env;
+	private final Environment env;
+	private final ApplicationContext context;
 
 	@Autowired
-	private ApplicationContext context;
+	public DebugBean(Environment env, ApplicationContext context) {
+		this.env = env;
+		this.context = context;
+	}
 
 	@PostConstruct
 	public void postConstruct() {

--- a/catwatch-backend/src/main/java/org/zalando/catwatch/backend/github/SnapshotProvider.java
+++ b/catwatch-backend/src/main/java/org/zalando/catwatch/backend/github/SnapshotProvider.java
@@ -12,7 +12,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 import org.zalando.catwatch.backend.model.util.Scorer;
 
@@ -39,23 +38,13 @@ public class SnapshotProvider {
 
     private static final Logger logger = LoggerFactory.getLogger(SnapshotProvider.class);
 
-    @Autowired
-    private Scorer scorer;
-
-    @Value("${cache.path}")
-    private String cachePath;
-
-    @Value("${cache.size}")
-    private Integer cacheSize;
-
-    @Value("${github.login:GITHUB_LOGIN}")
-    private String login;
-
-    @Value("${github.password:GITHUB_PASSWORD}")
-    private String password;
-
     private static final int MEGABYTE = 1024 * 1024;
 
+    private final Scorer scorer;
+    private final String cachePath;
+    private final Integer cacheSize;
+    private final String login;
+    private final String password;
     private final ExecutorService pool = Executors.newCachedThreadPool();
 
     /**
@@ -64,6 +53,19 @@ public class SnapshotProvider {
      * @see <a href="https://github.com/square/okhttp/wiki/Recipes#response-caching">OkHttp Wiki</a>
      */
     private OkHttpClient httpClient;
+
+    @Autowired
+    public SnapshotProvider(Scorer scorer,
+                            @Value("${cache.path}") String cachePath,
+                            @Value("${cache.size}") Integer cacheSize,
+                            @Value("${github.login:GITHUB_LOGIN}") String login,
+                            @Value("${github.password:GITHUB_PASSWORD}") String password) {
+        this.scorer = scorer;
+        this.cachePath = cachePath;
+        this.cacheSize = cacheSize;
+        this.login = login;
+        this.password = password;
+    }
 
     /**
      * Initializes cache after the bean is created

--- a/catwatch-backend/src/main/java/org/zalando/catwatch/backend/mail/MailSender.java
+++ b/catwatch-backend/src/main/java/org/zalando/catwatch/backend/mail/MailSender.java
@@ -13,14 +13,18 @@ import static java.util.stream.Collectors.joining;
 @Service
 public class MailSender {
 
+    private final JavaMailSender javaMailSender;
+    private final String destinationAddress;
+    private final String sourceAddress;
+
     @Autowired
-    private JavaMailSender javaMailSender;
-
-    @Value("${mail.to}")
-    private String destinationAddress;
-
-    @Value("${mail.from}")
-    private String sourceAddress;
+    public MailSender(JavaMailSender javaMailSender,
+                      @Value("${mail.to}") String destinationAddress,
+                      @Value("${mail.from}") String sourceAddress) {
+        this.javaMailSender = javaMailSender;
+        this.destinationAddress = destinationAddress;
+        this.sourceAddress = sourceAddress;
+    }
 
     public boolean send(Throwable e) {
         javaMailSender.send(createMessageFor(e));

--- a/catwatch-backend/src/main/java/org/zalando/catwatch/backend/repo/util/DatabasePopulator.java
+++ b/catwatch-backend/src/main/java/org/zalando/catwatch/backend/repo/util/DatabasePopulator.java
@@ -26,17 +26,21 @@ import org.zalando.catwatch.backend.repo.builder.StatisticsBuilder;
 @Component
 public class DatabasePopulator {
 
-    @Autowired
-    private StatisticsRepository statisticsRepository;
+    private final StatisticsRepository statisticsRepository;
+    private final ProjectRepository projectRepository;
+    private final ContributorRepository contributorRepository;
+    private final JdbcTemplate jdbcTemplate;
 
     @Autowired
-    private ProjectRepository projectRepository;
-
-    @Autowired
-    private ContributorRepository contributorRepository;
-
-    @Autowired
-    private JdbcTemplate jdbcTemplate;
+    public DatabasePopulator(StatisticsRepository statisticsRepository,
+                             ProjectRepository projectRepository,
+                             ContributorRepository contributorRepository,
+                             JdbcTemplate jdbcTemplate) {
+        this.statisticsRepository = statisticsRepository;
+        this.projectRepository = projectRepository;
+        this.contributorRepository = contributorRepository;
+        this.jdbcTemplate = jdbcTemplate;
+    }
 
     public void populateTestData() {
 

--- a/catwatch-backend/src/main/java/org/zalando/catwatch/backend/scheduler/Fetcher.java
+++ b/catwatch-backend/src/main/java/org/zalando/catwatch/backend/scheduler/Fetcher.java
@@ -34,20 +34,24 @@ public class Fetcher {
 
     private static final Logger logger = LoggerFactory.getLogger(Fetcher.class);
 
-    @Autowired
-    private ProjectRepository projectRepository;
+    private final ProjectRepository projectRepository;
+    private final StatisticsRepository statisticsRepository;
+    private final ContributorRepository contributorRepository;
+    private final SnapshotProvider snapshotProvider;
+    private final String[] organizations;
 
     @Autowired
-    private StatisticsRepository statisticsRepository;
-
-    @Autowired
-    private ContributorRepository contributorRepository;
-
-    @Autowired
-    private SnapshotProvider snapshotProvider;
-
-    @Value("#{'${organization.list}'.split(',')}")
-    private String[] organizations;
+    public Fetcher(ProjectRepository projectRepository,
+                   StatisticsRepository statisticsRepository,
+                   ContributorRepository contributorRepository,
+                   SnapshotProvider snapshotProvider,
+                   @Value("#{'${organization.list}'.split(',')}") String[] organizations) {
+        this.projectRepository = projectRepository;
+        this.statisticsRepository = statisticsRepository;
+        this.contributorRepository = contributorRepository;
+        this.snapshotProvider = snapshotProvider;
+        this.organizations = organizations;
+    }
 
     /**
      * This is used to fetch data from GitHub.

--- a/catwatch-backend/src/main/java/org/zalando/catwatch/backend/scheduler/RetryableFetcher.java
+++ b/catwatch-backend/src/main/java/org/zalando/catwatch/backend/scheduler/RetryableFetcher.java
@@ -19,19 +19,27 @@ import java.util.Map;
 @Component
 public class RetryableFetcher {
 
-    @Autowired
-    private Fetcher fetcher;
-    @Value("${fetcher.maxAttempts}")
-    private int maxAttempts;
-    @Value("${fetcher.initialInterval}")
-    private int initialInterval;
-    @Value("${fetcher.maxInterval}")
-    private int maxInterval;
-    @Value("${fetcher.multiplier}")
-    private double multiplier;
+    private final Fetcher fetcher;
+    private final int maxAttempts;
+    private final int initialInterval;
+    private final int maxInterval;
+    private final double multiplier;
+    private final MailSender mailSender;
 
     @Autowired
-    private MailSender mailSender;
+    public RetryableFetcher(Fetcher fetcher,
+                            @Value("${fetcher.maxAttempts}") int maxAttempts,
+                            @Value("${fetcher.initialInterval}") int initialInterval,
+                            @Value("${fetcher.maxInterval}") int maxInterval,
+                            @Value("${fetcher.multiplier}") double multiplier,
+                            MailSender mailSender) {
+        this.fetcher = fetcher;
+        this.maxAttempts = maxAttempts;
+        this.initialInterval = initialInterval;
+        this.maxInterval = maxInterval;
+        this.multiplier = multiplier;
+        this.mailSender = mailSender;
+    }
 
     public void tryFetchData() {
         RetryCallback<Boolean, RuntimeException> retryCallback = context -> {

--- a/catwatch-backend/src/main/java/org/zalando/catwatch/backend/scheduler/TaskScheduler.java
+++ b/catwatch-backend/src/main/java/org/zalando/catwatch/backend/scheduler/TaskScheduler.java
@@ -9,9 +9,12 @@ import org.springframework.stereotype.Component;
 @Profile("!test")
 public class TaskScheduler {
 
-    @Autowired
-    private RetryableFetcher fetcher;
+    private final RetryableFetcher fetcher;
 
+    @Autowired
+    public TaskScheduler(RetryableFetcher fetcher) {
+        this.fetcher = fetcher;
+    }
 
     /**
      * This is used to fetch every Organization statistics from GitHub.

--- a/catwatch-backend/src/main/java/org/zalando/catwatch/backend/service/LanguageService.java
+++ b/catwatch-backend/src/main/java/org/zalando/catwatch/backend/service/LanguageService.java
@@ -24,11 +24,15 @@ import org.zalando.catwatch.backend.util.StringParser;
 @Service
 public class LanguageService {
 
-	@Autowired
-	ProjectRepository repository;
-
     public static final Logger logger = LoggerFactory.getLogger(LanguageService.class);
-	
+
+	private final ProjectRepository repository;
+
+    @Autowired
+    public LanguageService(ProjectRepository repository) {
+        this.repository = repository;
+    }
+
     public List<Language> filterLanguages(List<Language> languages, int limit,  int offset){
          return  languages.stream().skip(offset).limit(limit).collect(Collectors.toList());
     }

--- a/catwatch-backend/src/main/java/org/zalando/catwatch/backend/service/ProjectServiceImpl.java
+++ b/catwatch-backend/src/main/java/org/zalando/catwatch/backend/service/ProjectServiceImpl.java
@@ -18,17 +18,18 @@ import java.util.stream.Collectors;
 @Service
 public class ProjectServiceImpl implements ProjectService {
 
-    @Autowired
-    ProjectRepository projectRepository;
-
-    @Autowired
-    private Environment env;
-
     private static final String SORT_ORDER_DESC = "-";
-
     private static final Integer DEFAULT_LIMIT = 5;
-
     private static final Integer DEFAULT_OFFSET = 0;
+
+    private final ProjectRepository projectRepository;
+    private final Environment env;
+
+    @Autowired
+    public ProjectServiceImpl(ProjectRepository projectRepository, Environment env) {
+        this.projectRepository = projectRepository;
+        this.env = env;
+    }
 
     @Override
     public Iterable<Project> findProjects(final String organizations, final Optional<Integer> limit,

--- a/catwatch-backend/src/main/java/org/zalando/catwatch/backend/web/ContributorsApi.java
+++ b/catwatch-backend/src/main/java/org/zalando/catwatch/backend/web/ContributorsApi.java
@@ -64,11 +64,14 @@ public class ContributorsApi {
     @EmbeddedId
     private ContributorKey key;
 
-    @Autowired
-    private ContributorRepository repository;
+    private final ContributorRepository repository;
+    private final Environment env;
 
     @Autowired
-    private Environment env;
+    public ContributorsApi(ContributorRepository repository, Environment env) {
+        this.repository = repository;
+        this.env = env;
+    }
 
     @ApiOperation(value = "Contributor", notes = "The Contributors endpoint returns all information like name, url, commits count, \nprojects count of all the Contributors for the selected filter. \n", response = Contributor.class, responseContainer = "List")
     @ApiResponses(value = {

--- a/catwatch-backend/src/main/java/org/zalando/catwatch/backend/web/LanguagesApi.java
+++ b/catwatch-backend/src/main/java/org/zalando/catwatch/backend/web/LanguagesApi.java
@@ -31,16 +31,17 @@ import io.swagger.annotations.ApiResponses;
 @Api(value = Constants.API_RESOURCE_LANGUAGES, description = "the languages API")
 public class LanguagesApi {
 
-	
 	private static final Integer DEFAULT_LIMIT = 5;
-
     private static final Integer DEFAULT_OFFSET = 0;
     
+    private final LanguageService languageService;
+    private final Environment env;
+
     @Autowired
-    LanguageService languageService;
-    
-    @Autowired
-    Environment env;
+    public LanguagesApi(LanguageService languageService, Environment env) {
+        this.languageService = languageService;
+        this.env = env;
+    }
 
     @ApiOperation(
         value = "Project programming language",

--- a/catwatch-backend/src/main/java/org/zalando/catwatch/backend/web/ProjectsApi.java
+++ b/catwatch-backend/src/main/java/org/zalando/catwatch/backend/web/ProjectsApi.java
@@ -7,7 +7,6 @@ import java.util.Date;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
-
 import org.springframework.format.annotation.DateTimeFormat;
 
 import org.springframework.http.HttpStatus;
@@ -36,8 +35,12 @@ import io.swagger.annotations.ApiResponses;
 @Api(value = Constants.API_RESOURCE_PROJECTS, description = "the projects API")
 public class ProjectsApi {
 
+    private final ProjectService projectService;
+
     @Autowired
-    private ProjectService projectService;
+    public ProjectsApi(ProjectService projectService) {
+        this.projectService = projectService;
+    }
 
     @ApiOperation(
         value = "Project",

--- a/catwatch-backend/src/main/java/org/zalando/catwatch/backend/web/StatisticsApi.java
+++ b/catwatch-backend/src/main/java/org/zalando/catwatch/backend/web/StatisticsApi.java
@@ -36,17 +36,21 @@ import org.zalando.catwatch.backend.util.*;
 @Api(value = Constants.API_RESOURCE_STATISTICS, description = "the statistics API")
 public class StatisticsApi {
 
-	@Autowired
-	private StatisticsRepository repository;
+	private final StatisticsRepository repository;
+	private final ProjectRepository projectRepository;
+    private final ContributorRepository contributorRepository;
+	private final Environment env;
 
 	@Autowired
-	private ProjectRepository projectRepository;
-
-    @Autowired
-    private ContributorRepository contributorRepository;
-
-	@Autowired
-	private Environment env;
+	public StatisticsApi(StatisticsRepository repository,
+						 ProjectRepository projectRepository,
+						 ContributorRepository contributorRepository,
+						 Environment env) {
+		this.repository = repository;
+		this.projectRepository = projectRepository;
+		this.contributorRepository = contributorRepository;
+		this.env = env;
+	}
 
 	@ApiOperation(value = "General Statistics of list of Github.com Organizations", notes = "The Statistics endpoint returns snapshot of statistics over a given period of time of the organization \nGithub account. Statistics contains information of the count of all private projects,  public projects,              members, teams, contributors, stars, forks, size, programming languages, tags of the list of Github.com              Organizations.\n", response = Statistics.class, responseContainer = "List")
 	@ApiResponses(value = { @ApiResponse(code = 200, message = "An array of Statistics over selected period of time."),

--- a/catwatch-backend/src/main/java/org/zalando/catwatch/backend/web/StatisticsApi.java
+++ b/catwatch-backend/src/main/java/org/zalando/catwatch/backend/web/StatisticsApi.java
@@ -38,7 +38,7 @@ public class StatisticsApi {
 
 	private final StatisticsRepository repository;
 	private final ProjectRepository projectRepository;
-    private final ContributorRepository contributorRepository;
+	private final ContributorRepository contributorRepository;
 	private final Environment env;
 
 	@Autowired

--- a/catwatch-backend/src/main/java/org/zalando/catwatch/backend/web/admin/AdminController.java
+++ b/catwatch-backend/src/main/java/org/zalando/catwatch/backend/web/admin/AdminController.java
@@ -29,26 +29,30 @@ import static java.util.Arrays.stream;
 @Controller
 public class AdminController {
 
-    @Autowired
-    private ContributorRepository contributorRepository;
+    private final ContributorRepository contributorRepository;
+    private final StatisticsRepository statisticsRepository;
+    private final ProjectRepository projectRepository;
+    private final DatabasePopulator databasePopulator;
+    private final Scorer scorer;
+    private final String organizations;
+    private final String scoringProject;
 
     @Autowired
-    private StatisticsRepository statisticsRepository;
-
-    @Autowired
-    private ProjectRepository projectRepository;
-
-    @Autowired
-    private DatabasePopulator databasePopulator;
-
-    @Autowired
-    private Scorer scorer;
-
-    @Value("${organization.list}")
-    private String organizations;
-
-    @Value("${scoring.project}")
-    private String scoringProject;
+    public AdminController(ContributorRepository contributorRepository,
+                           StatisticsRepository statisticsRepository,
+                           ProjectRepository projectRepository,
+                           DatabasePopulator databasePopulator,
+                           Scorer scorer,
+                           @Value("${organization.list}") String organizations,
+                           @Value("${scoring.project}") String scoringProject) {
+        this.contributorRepository = contributorRepository;
+        this.statisticsRepository = statisticsRepository;
+        this.projectRepository = projectRepository;
+        this.databasePopulator = databasePopulator;
+        this.scorer = scorer;
+        this.organizations = organizations;
+        this.scoringProject = scoringProject;
+    }
 
     @RequestMapping(value = "/config/scoring.project", method = POST, produces = "application/json; charset=utf-8")
     @ResponseBody

--- a/catwatch-backend/src/main/java/org/zalando/catwatch/backend/web/config/ConfigController.java
+++ b/catwatch-backend/src/main/java/org/zalando/catwatch/backend/web/config/ConfigController.java
@@ -1,24 +1,28 @@
 package org.zalando.catwatch.backend.web.config;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
-import static org.springframework.web.bind.annotation.RequestMethod.GET;
-
-import java.util.Map;
-import java.util.Properties;
-import java.util.SortedMap;
-import java.util.TreeMap;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import java.util.Map;
+import java.util.Properties;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
 @Controller
 public class ConfigController {
 
+    private final Environment env;
+
     @Autowired
-    private Environment env;
+    public ConfigController(Environment env) {
+        this.env = env;
+    }
 
     @RequestMapping(value = "/config", method = GET, produces = { APPLICATION_JSON_VALUE })
     @ResponseBody

--- a/catwatch-backend/src/main/java/org/zalando/catwatch/backend/web/fetch/FetchController.java
+++ b/catwatch-backend/src/main/java/org/zalando/catwatch/backend/web/fetch/FetchController.java
@@ -10,8 +10,12 @@ import org.zalando.catwatch.backend.scheduler.RetryableFetcher;
 @Controller
 public class FetchController {
 
+	private final RetryableFetcher fetcher;
+
 	@Autowired
-	private RetryableFetcher fetcher;
+	public FetchController(RetryableFetcher fetcher) {
+		this.fetcher = fetcher;
+	}
 
 	@RequestMapping(value = "/fetch", method = RequestMethod.GET, produces = "application/json; charset=utf-8")
 	@ResponseBody

--- a/catwatch-backend/src/test/java/org/zalando/catwatch/backend/scheduler/FetcherTest.java
+++ b/catwatch-backend/src/test/java/org/zalando/catwatch/backend/scheduler/FetcherTest.java
@@ -1,38 +1,17 @@
 package org.zalando.catwatch.backend.scheduler;
 
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.zalando.catwatch.backend.CatWatchBackendApplication;
+import org.zalando.catwatch.backend.mail.MailSender;
 
 import static org.mockito.Mockito.*;
 
-/**
- * Created by jgolebiowski on 8/18/15.
- */
-@RunWith(SpringJUnit4ClassRunner.class)
-@TestPropertySource(properties = {"fetcher.initialInterval=100", "fetcher.multiplier=2", "fetcher.maxAttempts=5"})
-@SpringApplicationConfiguration(classes = CatWatchBackendApplication.class)
 public class FetcherTest {
 
-    @InjectMocks
-    @Autowired
-    private RetryableFetcher retryableFetcher;
+    private final static int MAX_ATTEMPTS = 3;
 
-    @Mock
-    private Fetcher fetcher;
-
-    @Before
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
-    }
+    private final Fetcher fetcher = mock(Fetcher.class);
+    private final MailSender mailSender = mock(MailSender.class);
+    private final RetryableFetcher retryableFetcher = new RetryableFetcher(fetcher, MAX_ATTEMPTS, 0, 0, 0, mailSender);
 
     @Test
     public void shouldRetryThreeTimes() throws Exception {

--- a/catwatch-backend/src/test/java/org/zalando/catwatch/backend/scheduler/MailOnRetryTest.java
+++ b/catwatch-backend/src/test/java/org/zalando/catwatch/backend/scheduler/MailOnRetryTest.java
@@ -22,7 +22,7 @@ public class MailOnRetryTest {
 
     private final Fetcher fetcher = mock(Fetcher.class);
     private final MailSender mailSender = mock(MailSender.class);
-    private final RetryableFetcher retryableFetcher = new RetryableFetcher(fetcher, 1, 0, 0, 0, mailSender);
+    private final RetryableFetcher retryableFetcher = new RetryableFetcher(fetcher, MAX_ATTEMPTS, 0, 0, 0, mailSender);
 
     @Test
     public void shouldSendMailOnCrawlerFailure() throws Exception {

--- a/catwatch-backend/src/test/java/org/zalando/catwatch/backend/scheduler/MailOnRetryTest.java
+++ b/catwatch-backend/src/test/java/org/zalando/catwatch/backend/scheduler/MailOnRetryTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -15,28 +16,13 @@ import org.zalando.catwatch.backend.mail.MailSender;
 
 import static org.mockito.Mockito.*;
 
-/**
- * Created by jgolebiowski on 8/18/15.
- */
-@RunWith(SpringJUnit4ClassRunner.class)
-@TestPropertySource(properties = {"fetcher.initialInterval=100", "fetcher.multiplier=2", "fetcher.maxAttempts=1"})
-@SpringApplicationConfiguration(classes = CatWatchBackendApplication.class)
 public class MailOnRetryTest {
 
-    @InjectMocks
-    @Autowired
-    private RetryableFetcher retryableFetcher;
+    private final static int MAX_ATTEMPTS = 1;
 
-    @Mock
-    private Fetcher fetcher;
-
-    @Mock
-    private MailSender mailSender;
-
-    @Before
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
-    }
+    private final Fetcher fetcher = mock(Fetcher.class);
+    private final MailSender mailSender = mock(MailSender.class);
+    private final RetryableFetcher retryableFetcher = new RetryableFetcher(fetcher, 1, 0, 0, 0, mailSender);
 
     @Test
     public void shouldSendMailOnCrawlerFailure() throws Exception {

--- a/catwatch-backend/src/test/java/org/zalando/catwatch/backend/service/LanguageServiceTest.java
+++ b/catwatch-backend/src/test/java/org/zalando/catwatch/backend/service/LanguageServiceTest.java
@@ -25,11 +25,11 @@ public class LanguageServiceTest {
 
     public static final Logger logger = LoggerFactory.getLogger(LanguageServiceTest.class);
 
-    @InjectMocks
-    LanguageService languageService = new LanguageService();
-
     @Mock
     ProjectRepository projectRepository;
+
+    @InjectMocks
+    LanguageService languageService;
 
     /**
      *  Checking if the language with name null is ignored


### PR DESCRIPTION
- Use constructor injection. Field injection hides the dependencies that
  the class needs, constructor forces the client to pass them making it more
  clear what the class needs. Fields also had different visibilities, changed
  everything to be "private final"
- Fixed tests that broke because of this change
