### PR TITLE
Build docker image using CDP

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -1,0 +1,1 @@
+X-Zalando-Team: opensource

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -1,0 +1,13 @@
+build_steps:
+- desc: Install dependencies
+  cmd: |
+    apt-get update
+    apt-get install -y apt-transport-https ca-certificates curl openjdk-8-jdk
+    curl -sSL https://get.docker.com/ | sh
+- desc: Build and push docker image
+  cmd: |
+    image=registry-write.opensource.zalan.do/opensource/catwatch:${CDP_BUILD_VERSION}
+    cd catwatch-backend
+    ../mvnw --batch-mode package
+    docker build -t $image .
+    docker push $image


### PR DESCRIPTION
Build and push Docker image to OSS registry via CDP (delivery.yaml). This only works for master branch.