### PR TITLE
use latest openjdk image

### DIFF
--- a/catwatch-backend/Dockerfile
+++ b/catwatch-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8-30
+FROM registry.opensource.zalan.do/stups/openjdk:latest
 
 EXPOSE 8080
 
@@ -7,4 +7,3 @@ CMD java $JAVA_OPTS $(java-dynamic-memory-opts) -jar /catwatch-backend.jar
 COPY target/catwatch-backend.jar /catwatch-backend.jar
 
 COPY target/generated-sources/scm-source.json /scm-source.json
-


### PR DESCRIPTION
This fixes several CVEs according to clair.

However, main purpose is to trigger another CDP build :innocent: