### PR TITLE
Add zalando-research to the list of crawled organizations

### DIFF
--- a/catwatch-backend/src/main/resources/application.properties
+++ b/catwatch-backend/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 endpoints.enabled=false
 endpoints.health.enabled=true
 
-organization.list=zalando,zalando-stups,zalando-incubator
+organization.list=zalando,zalando-stups,zalando-incubator,zalando-research
 
 #default size of returned languages/projects items
 default.item.limit=5


### PR DESCRIPTION
Adds zalando-research to the list of crawled organizations.

Fixes https://github.com/zalando-incubator/catwatch/issues/72