### PR TITLE
#77 Change team name to opensourceguild in zappr.yaml

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -6,4 +6,4 @@ approvals:
         orgs:
           - "zalando"
 
-X-Zalando-Team: opensource
+X-Zalando-Team: opensourceguild


### PR DESCRIPTION
The right team id is "opensourceguild" (see email to opensource guild today)